### PR TITLE
Fixes #4 OPEN_DIALOG action fired twice

### DIFF
--- a/src/redux-dialog.js
+++ b/src/redux-dialog.js
@@ -29,11 +29,6 @@ const reduxDialog = (defaults) => {
     };
 
     const mapDispatchToProps = (dispatch, props) => ({
-      onAfterOpen: () => {
-        props.onAfterOpen && props.onAfterOpen();
-        dispatch(openDialog(name))
-      },
-
       onRequestClose: () => {
         props.onRequestClose && props.onRequestClose();
         dispatch(closeDialog(name))


### PR DESCRIPTION
From react-modal docs:
>Because the open and closed state of the modal should be controlled outside of the modal, **you need to provide the onRequestClose** function prop to actually set the state.

openDialog should not be dispatched from onAfterOpen